### PR TITLE
dlang support, delimiter temp filename option for dlang

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,8 @@
             "autoit": "autoit3",
             "kotlin": "cd $dir && kotlinc $fileName -include-runtime -d $fileNameWithoutExt.jar && java -jar $fileNameWithoutExt.jar",
             "dart": "dart",
-            "pascal": "cd $dir && fpc $fileName && $dir$fileNameWithoutExt"
+            "pascal": "cd $dir && fpc $fileName && $dir$fileNameWithoutExt",
+            "d": "cd $dir && dmd $fileName && $dir$fileNameWithoutExt"
           },
           "description": "Set the executor of each language."
         },
@@ -149,7 +150,8 @@
             ".kts": "kotlinc -script",
             ".dart": "dart",
             ".pas": "cd $dir && fpc $fileName && $dir$fileNameWithoutExt",
-            ".pp": "cd $dir && fpc $fileName && $dir$fileNameWithoutExt"
+            ".pp": "cd $dir && fpc $fileName && $dir$fileNameWithoutExt",
+            ".d": "cd $dir && dmd $fileName && $dir$fileNameWithoutExt"
           },
           "description": "Set the executor of each file extension."
         },

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -158,7 +158,7 @@ export class CodeManager {
                 fileType = '.' + this._languageId;
             }
         }
-        let tmpFileName = 'temp-' + this.rndName() + fileType;
+        let tmpFileName = 'temp' + this.rndName() + fileType;
         this._codeFile = join(folder, tmpFileName);
         fs.writeFileSync(this._codeFile, content);
     }


### PR DESCRIPTION
had to change "temp-" to temp + optional delimiter, otherwise dmd compiler throws errors because module names must be valid language expressions