### PR TITLE
Fix #98: Add .ts extension for typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,8 @@
           "type": "object",
           "default": {
             "bat": ".bat",
-            "powershell": ".ps1"
+            "powershell": ".ps1",
+            "typescript": ".ts"
           },
           "description": "Set the mapping of languageId to file extension."
         },


### PR DESCRIPTION
This is needed for ts-node to interpret typescript files correctly.