### PR TITLE
Fix kotlin script execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,6 @@
             "racket": "racket",
             "ahk": "autohotkey",
             "autoit": "autoit3",
-            "kotlin": "cd $dir && kotlinc $fileName -include-runtime -d $fileNameWithoutExt.jar && java -jar $fileNameWithoutExt.jar",
             "dart": "dart",
             "pascal": "cd $dir && fpc $fileName && $dir$fileNameWithoutExt",
             "d": "cd $dir && dmd $fileName && $dir$fileNameWithoutExt",


### PR DESCRIPTION
It seems like the properties given by `executorMap` take precedence. I've removed the line for kotlin so it uses the properties given in `executorMapByFileExtension` instead.