### PR TITLE
Added commits to enable executing Perl 6 code 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-runner",
   "displayName": "Code Runner",
-  "description": "Run C, C++, Java, JS, PHP, Python, Perl, Ruby, Go, Lua, Groovy, PowerShell, CMD, BASH, F#, C#, VBScript, TypeScript, CoffeeScript, Scala, Swift, Julia, Crystal, OCaml, R, AppleScript, Elixir, VB.NET, Clojure, Haxe, Objective-C, Rust, Racket, AutoHotkey, AutoIt, Kotlin, Dart, Pascal, Haskell, Nim, D",
+  "description": "Run C, C++, Java, JS, PHP, Python, Perl, Perl 6, Ruby, Go, Lua, Groovy, PowerShell, CMD, BASH, F#, C#, VBScript, TypeScript, CoffeeScript, Scala, Swift, Julia, Crystal, OCaml, R, AppleScript, Elixir, VB.NET, Clojure, Haxe, Objective-C, Rust, Racket, AutoHotkey, AutoIt, Kotlin, Dart, Pascal, Haskell, Nim, D",
   "version": "0.8.6",
   "publisher": "formulahendry",
   "icon": "images/logo.png",
@@ -17,6 +17,7 @@
     "php",
     "python",
     "perl",
+    "perl6",
     "ruby",
     "multi-root ready"
   ],
@@ -119,6 +120,7 @@
             "php": "php",
             "python": "python",
             "perl": "perl",
+            "perl6": "perl6",
             "ruby": "ruby",
             "go": "go run",
             "lua": "lua",

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
             ".vbs": "cscript //Nologo",
             ".scala": "scala",
             ".jl": "julia",
+            ".p6": "perl6",
             ".cr": "crystal",
             ".ml": "ocaml",
             ".exs": "elixir",


### PR DESCRIPTION
Edited `package.json` file to enable execution of Perl 6 code within code runner.
It recognises `.p6` files as Perl 6 scripts and execute via `perl6` executable.

As Perl 6 language is mature and with clean syntax and reasonable learning curve similar to python, its time to extend support to Perl 6.
This is my effort.