### PR TITLE
Set focus to integrated terminal after run

### DIFF
--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -409,6 +409,7 @@ export class CodeManager implements vscode.Disposable {
             this._terminal.sendText(`cd "${cwd}"`);
         }
         this._terminal.sendText(command);
+        await vscode.commands.executeCommand("workbench.action.terminal.focus");
     }
 
     private executeCommandInOutputChannel(executor: string, appendFile: boolean = true) {


### PR DESCRIPTION
Currently when you want to input characters after running, you have to click the integrated terminal to bring it into focus. This changes saves an additional click by bringing focus to the terminal automatically.