### PR TITLE
Add shebang support

### DIFF
--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -95,12 +95,6 @@ export class CodeManager implements vscode.Disposable {
         const executorMap = config.get<any>("executorMap");
 
         let languages = Object.keys(executorMap);
-
-        const firstLineInFile = vscode.window.activeTextEditor.document.lineAt(0).text;
-        if (firstLineInFile.startsWith("#!")) {
-            languages = [firstLineInFile.substr(2)].concat(languages);
-        }
-
         vscode.window.showQuickPick(languages, { placeHolder: "Type or select language to run" }).then((languageId) => {
             if (languageId !== undefined) {
                 this.run(languageId);

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -57,7 +57,7 @@ export class CodeManager implements vscode.Disposable {
         let executor = null;
 
         const firstLineInFile = this._document.lineAt(0).text;
-        if (firstLineInFile.startsWith('#!')) {
+        if (firstLineInFile.startsWith("#!")) {
             executor = firstLineInFile.substr(2);
         } else {
             executor = this.getExecutor(languageId, fileExtension);
@@ -104,7 +104,7 @@ export class CodeManager implements vscode.Disposable {
         let languages = Object.keys(executorMap);
 
         const firstLineInFile = vscode.window.activeTextEditor.document.lineAt(0).text;
-        if (firstLineInFile.startsWith('#!')) {
+        if (firstLineInFile.startsWith("#!")) {
             languages = [firstLineInFile.substr(2)].concat(languages);
         }
 

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -54,14 +54,7 @@ export class CodeManager implements vscode.Disposable {
         this.initialize();
 
         const fileExtension = extname(this._document.fileName);
-        let executor = null;
-
-        const firstLineInFile = this._document.lineAt(0).text;
-        if (firstLineInFile.startsWith("#!")) {
-            executor = firstLineInFile.substr(2);
-        } else {
-            executor = this.getExecutor(languageId, fileExtension);
-        }
+        const executor = this.getExecutor(languageId, fileExtension);
 
         // undefined or null
         if (executor == null) {
@@ -254,8 +247,23 @@ export class CodeManager implements vscode.Disposable {
 
     private getExecutor(languageId: string, fileExtension: string): string {
         this._languageId = languageId === null ? this._document.languageId : languageId;
+
+        let executor = null;
+
+        // Check if file contains hash-bang
+        if (languageId == null) {
+            const firstLineInFile = this._document.lineAt(0).text;
+            if (firstLineInFile.startsWith("#!")) {
+                executor = firstLineInFile.substr(2);
+            }
+        }
+
         const executorMap = this._config.get<any>("executorMap");
-        let executor = executorMap[this._languageId];
+
+        if (executor == null) {
+            executor = executorMap[this._languageId];
+        }
+
         // executor is undefined or null
         if (executor == null && fileExtension) {
             const executorMapByFileExtension = this._config.get<any>("executorMapByFileExtension");

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -55,7 +55,6 @@ export class CodeManager implements vscode.Disposable {
 
         const fileExtension = extname(this._document.fileName);
         const executor = this.getExecutor(languageId, fileExtension);
-
         // undefined or null
         if (executor == null) {
             vscode.window.showInformationMessage("Code language not supported or defined.");

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -93,9 +93,7 @@ export class CodeManager implements vscode.Disposable {
         this._appInsightsClient.sendEvent("runByLanguage");
         const config = this.getConfiguration();
         const executorMap = config.get<any>("executorMap");
-
-        let languages = Object.keys(executorMap);
-        vscode.window.showQuickPick(languages, { placeHolder: "Type or select language to run" }).then((languageId) => {
+        vscode.window.showQuickPick(Object.keys(executorMap), { placeHolder: "Type or select language to run" }).then((languageId) => {
             if (languageId !== undefined) {
                 this.run(languageId);
             }

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -62,7 +62,7 @@ export class CodeManager implements vscode.Disposable {
         } else {
             executor = this.getExecutor(languageId, fileExtension);
         }
-        
+
         // undefined or null
         if (executor == null) {
             vscode.window.showInformationMessage("Code language not supported or defined.");


### PR DESCRIPTION
- By default check shebang in file and if any is present run file with it

Shebang is a very convenient way to define executor on per-file basis. This is useful for python which currently has two major non-compatible versions and maybe some other languages too.
Also this is easier than switching config when you need to run only one file.

More: [https://en.wikipedia.org/wiki/Shebang_(Unix)](https://en.wikipedia.org/wiki/Shebang_(Unix))