### PR TITLE
adding clisp as default lisp

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,8 @@
             "pascal": "cd $dir && fpc $fileName && $dir$fileNameWithoutExt",
             "d": "cd $dir && dmd $fileName && $dir$fileNameWithoutExt",
             "haskell": "runhaskell",
-            "nim": "nim compile --verbosity:0 --hints:off --run"
+            "nim": "nim compile --verbosity:0 --hints:off --run",
+            "lisp": "cd $dir && clisp -disable-readline $dir$fileName"
           },
           "description": "Set the executor of each language.",
           "scope": "resource"


### PR DESCRIPTION
it runs *.lisp files, but: at least on my system clisp reports an error on exit, I suspect there is a bug somewhere in CLISP [based on some googling and research]

anyway, it works for running lisp code