### PR TITLE
Added quotedFileName option -> whether to quote FileName,Path and etc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -323,6 +323,12 @@
           "default": true,
           "description": "Whether to respect Shebang to run code.",
           "scope": "resource"
+        },
+        "code-runner.quatedFileName":{
+          "type":"boolean",
+          "default":false,
+          "description": "Whether to quote FileName,Path and etc.",
+          "scope": "resource"
         }
       }
     },

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -25,6 +25,7 @@ export class CodeManager implements vscode.Disposable {
     private _config: vscode.WorkspaceConfiguration;
     private _appInsightsClient: AppInsightsClient;
     private _TERMINAL_DEFAULT_SHELL_WINDOWS: string | null = null;
+    private _isQuotedFileName: boolean;
 
     constructor() {
         this._outputChannel = vscode.window.createOutputChannel("Code");
@@ -151,6 +152,7 @@ export class CodeManager implements vscode.Disposable {
             return;
         }
         this._cwd = TmpDir;
+        this._isQuotedFileName= this._config.get<boolean>("quatedFileName");
     }
 
     private getConfiguration(section?: string): vscode.WorkspaceConfiguration {
@@ -339,7 +341,9 @@ export class CodeManager implements vscode.Disposable {
      * Includes double quotes around a given file name.
      */
     private quoteFileName(fileName: string): string {
-        return '\"' + fileName + '\"';
+        if(this._isQuotedFileName)
+            return '\"' + fileName + '\"';
+        return fileName;
     }
 
     /**


### PR DESCRIPTION
Hi,
I added Added quotedFileName option -> whether to quote FileName,Path and etc.
I think that will be useful to have option to quote commands yourself. For example after setting quotedFileName=false command line of starting  groovy from docker will look like: 
_docker run --rm -v **c:/temp**:/home/groovy/scripts -w /home/groovy/scripts groovy:latest groovy tempCodeRunnerFile.groovy_.Without the option home folder will be quoted and the call failes 