### PR TITLE
Add support for Less.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-runner",
   "displayName": "Code Runner",
-  "description": "Run C, C++, Java, JS, PHP, Python, Perl, Ruby, Go, Lua, Groovy, PowerShell, CMD, BASH, F#, C#, VBScript, TypeScript, CoffeeScript, Scala, Swift, Julia, Crystal, OCaml, R, AppleScript, Elixir, VB.NET, Clojure, Haxe, Obj-C, Rust, Racket, Scheme, AutoHotkey, AutoIt, Kotlin, Dart, Pascal, Haskell, Nim, D, Lisp, Kit, V, SCSS, Sass, CUDA",
+  "description": "Run C, C++, Java, JS, PHP, Python, Perl, Ruby, Go, Lua, Groovy, PowerShell, CMD, BASH, F#, C#, VBScript, TypeScript, CoffeeScript, Scala, Swift, Julia, Crystal, OCaml, R, AppleScript, Elixir, VB.NET, Clojure, Haxe, Obj-C, Rust, Racket, Scheme, AutoHotkey, AutoIt, Kotlin, Dart, Pascal, Haskell, Nim, D, Lisp, Kit, V, SCSS, Sass, CUDA, Less",
   "version": "0.10.0",
   "featureFlags": {
     "usingNewPythonInterpreterPathApi": true
@@ -166,7 +166,8 @@
             "kit": "kitc --run",
             "v": "v run",
             "sass": "sass --style expanded",
-            "scss": "scss --style expanded"
+            "scss": "scss --style expanded",
+            "less": "cd $dir && lessc $fileName $fileNameWithoutExt.css"
           },
           "description": "Set the executor of each language.",
           "scope": "resource"


### PR DESCRIPTION
Less is a widely-used CSS preprocessor, just like Sass and SCSS. I've found that code-runner supports Sass and SCSS, so I add support for Less.