### PR TITLE
Fix a typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Eliminate context switching and costly distractions. Create and merge PRs and pe
 
 ![Book](https://s1.ax1x.com/2020/07/03/NjzLtA.jpg)
 
-## WeChat Public Account
+## WeChat Official Account
 
 VS Code 的热门文章、使用技巧、插件推荐、插件开发攻略等，请关注“**玩转VS Code**”公众号！
 


### PR DESCRIPTION
The translation of "公众号" is "Official Accounts"

<img width="540" alt="wechat" src="https://user-images.githubusercontent.com/60951091/103222890-038a1080-4960-11eb-8cc1-3b7f13e299b3.png">
