### PR TITLE
fix the c++ compile error when use lambda etc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
             "javascript": "node",
             "java": "cd $dir && javac $fileName && java $fileNameWithoutExt",
             "c": "cd $dir && gcc $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
-            "cpp": "cd $dir && g++ $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
+            "cpp": "cd $dir && clang++ $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
             "objective-c": "cd $dir && gcc -framework Cocoa $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
             "php": "php",
             "python": "python -u",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     },
     "configuration": {
       "type": "object",
-      "title": "Run Code configuration",
+      "title": "Code Runner configuration",
       "properties": {
         "code-runner.executorMapByGlob": {
           "type": "object",


### PR DESCRIPTION
fix the c++ compile error use g++ when use lambda etc.


error: expected expression ;  
error: expected ';' at end of declaration;  
warning: range-based for loop is a C++11 extension [-Wc++11-extensions];


Mac 系统下 如果 g++ 编译  lambda  错误等问题修复 