### PR TITLE
Add stop button in editor title bar

### DIFF
--- a/images/stop-dark.svg
+++ b/images/stop-dark.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#C5C5C5;stroke-width:1.1;stroke-miterlimit:10;}
+</style>
+<path class="st0" d="M12.5,13.7h-9c-0.7,0-1.3-0.6-1.3-1.3v-9c0-0.7,0.6-1.3,1.3-1.3h9c0.7,0,1.3,0.6,1.3,1.3v9
+	C13.8,13.1,13.2,13.7,12.5,13.7z"/>
+</svg>

--- a/images/stop-light.svg
+++ b/images/stop-light.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#474748;stroke-width:1.1;stroke-miterlimit:10;}
+</style>
+<path class="st0" d="M12.5,13.7h-9c-0.7,0-1.3-0.6-1.3-1.3v-9c0-0.7,0.6-1.3,1.3-1.3h9c0.7,0,1.3,0.6,1.3,1.3v9
+	C13.8,13.1,13.2,13.7,12.5,13.7z"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -60,7 +60,11 @@
       },
       {
         "command": "code-runner.stop",
-        "title": "Stop Code Run"
+        "title": "Stop Code Run",
+        "icon": {
+          "light": "./images/stop-light.svg",
+          "dark": "./images/stop-dark.svg"
+        }
       }
     ],
     "keybindings": [
@@ -98,6 +102,13 @@
         {
           "when": "config.code-runner.showRunIconInEditorTitleMenu",
           "command": "code-runner.run",
+          "group": "navigation"
+        }
+      ],
+      "editor/title": [
+        {
+          "when": "config.code-runner.showStopIconInEditorTitleMenu && code-runner.codeRunning",
+          "command": "code-runner.stop",
           "group": "navigation"
         }
       ],
@@ -305,6 +316,12 @@
           "type": "boolean",
           "default": true,
           "description": "Whether to show 'Run Code' icon in editor title menu.",
+          "scope": "resource"
+        },
+        "code-runner.showStopIconInEditorTitleMenu": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to show 'Stop code run' icon in the editor title menu when code is running.",
           "scope": "resource"
         },
         "code-runner.showRunCommandInEditorContextMenu": {

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -129,6 +129,7 @@ export class CodeManager implements vscode.Disposable {
     private stopRunning() {
         if (this._isRunning) {
             this._isRunning = false;
+            vscode.commands.executeCommand('setContext', 'code-runner.codeRunning', false);
             const kill = require("tree-kill");
             kill(this._process.pid);
         }
@@ -466,6 +467,7 @@ export class CodeManager implements vscode.Disposable {
 
     private async executeCommandInOutputChannel(executor: string, appendFile: boolean = true) {
         this._isRunning = true;
+        vscode.commands.executeCommand('setContext', 'code-runner.codeRunning', true);
         const clearPreviousOutput = this._config.get<boolean>("clearPreviousOutput");
         if (clearPreviousOutput) {
             this._outputChannel.clear();
@@ -491,6 +493,7 @@ export class CodeManager implements vscode.Disposable {
 
         this._process.on("close", (code) => {
             this._isRunning = false;
+            vscode.commands.executeCommand('setContext', 'code-runner.codeRunning', false);
             const endTime = new Date();
             const elapsedTime = (endTime.getTime() - startTime.getTime()) / 1000;
             this._outputChannel.appendLine("");


### PR DESCRIPTION
Adds a "Stop code run" button in the editor title bar that appears when code is running.

The button can be turned off with the configuration option "code-runner.showStopIconInEditorTitleMenu", which is set to True by default.