### PR TITLE
Use single quotes around paths when outputing to Windows PowerShell

### DIFF
--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -339,6 +339,9 @@ export class CodeManager implements vscode.Disposable {
      * Includes double quotes around a given file name.
      */
     private quoteFileName(fileName: string): string {
+        if(this._config.get("runInTerminal") && os.platform() === "win32" && vscode.env.shell.toLowerCase().includes("powershell")) {
+            return "'" + fileName + "'";
+        }
         return '\"' + fileName + '\"';
     }
 
@@ -450,7 +453,11 @@ export class CodeManager implements vscode.Disposable {
         }
         if (this._config.get<boolean>("fileDirectoryAsCwd")) {
             const cwd = this.changeFilePathForBashOnWindows(this._cwd);
-            this._terminal.sendText(`cd "${cwd}"`);
+            if(os.platform() === "win32" && vscode.env.shell.toLowerCase().includes("powershell")) {
+                this._terminal.sendText(`cd '${cwd}'`);
+            } else {
+                this._terminal.sendText(`cd "${cwd}"`);
+            }
         }
         this._terminal.sendText(command);
     }


### PR DESCRIPTION
This is a proposal to use single quotes around paths when using Windows PowerShell.

Code Runner's "run in terminal" operation failed on my Windows machine due to my path having a special character ($) in it.

Because the $ sign is considered a variable by PowerShell when in double quotes, the extension's following commands were misinterpreted:

```
cd "C:\$directory1\directory2"
py -u "C:\$directory1\directory2\tempfile.python"
```

The above was interpreted as:

```
cd "C:\directory2"
py -u "C:\directory2\tempfile.python"
```

The proposed changes in this pull request would check if Windows PowerShell is being used, and implement single quotes instead of double quotes.

It's not very elegant, but I am unaware of a solution that doesn't require making a special case for PowerShell. For example, Windows cmd.exe would fail with single quotes, as would the extension's default output channel.

