### PR TITLE
Make paths safe for Windows PowerShell

### DIFF
--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -425,6 +425,8 @@ export class CodeManager implements vscode.Disposable {
                     .replace(/\\/g, "/");
             } else if (windowsShell && windowsShell.toLowerCase().indexOf("bash") > -1 && windowsShell.toLowerCase().indexOf("windows") > -1) {
                 command = command.replace(/([A-Za-z]):\\/g, this.replacer).replace(/\\/g, "/");
+            } else if (windowsShell && windowsShell.toLowerCase().indexOf("powershell") > -1) {
+                command = command.replace(/[$`]/g, "`$&");
             }
         }
         return command;


### PR DESCRIPTION
Backticks **`** and dollar signs **$** break paths for Windows Powershell, and must be escaped with backticks. For example:

These paths:
```
"C:\Sam`s Folder\$temp"
"C:\Sam`s Folder\$temp\tempfile.python"
```
Must be replaced with these paths:
```
"C:\Sam``s Folder\`$temp"
"C:\Sam``s Folder\`$temp\tempfile.python"
```

This code checks if Windows PowerShell is being used and escapes these characters if present.