### PR TITLE
Running Java code with packages #169

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ e.g. To set the executor PATH for ruby, php and html:
   * $fileNameWithoutExt: The base name of the code file being run without its extension
   * $driveLetter: The drive letter of the code file being run (Windows only)
   * $pythonPath: The path of Python interpreter (set by `Python: Select Interpreter` command)
+  * $javaPackageName: package name of the class in java
+  * $workspaceRootWithQuotes: workspace root directory with quotes (for windows)
 
 **Please take care of the back slash and the space in file path of the executor**
   * Back slash: please use `\\`

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -321,6 +321,32 @@ export class CodeManager implements vscode.Disposable {
     }
 
     /**
+     * Gets the package name for a java file.
+     */
+    private getJavaFilePackageName(): string {
+        const linecount = this._document.lineCount;
+        var packageName = "";
+        var packageRegEx = /package/gi;
+        var classRegEx = /public class/gi
+        for (var i = 0; i < linecount; i++) {
+            var line = this._document.lineAt(i);
+            if (line.text.search(packageRegEx) != -1) {
+                packageName = line.text.replace(packageRegEx, "");
+                packageName = packageName.trim();
+                packageName = packageName.replace(/;/gi, ".");
+                console.log("found package: " + packageName);
+                break;
+            }
+            if (line.text.search(classRegEx) != -1) {
+                console.log("found public class declaration");
+                break;
+            }
+        }
+        console.log("returning package name: " + packageName);
+        return packageName;
+    }
+
+    /**
      * Gets the drive letter of the code file.
      */
     private getDriveLetter(): string {
@@ -360,6 +386,8 @@ export class CodeManager implements vscode.Disposable {
             const codeFileDir = this.getCodeFileDir();
             const pythonPath = cmd.includes("$pythonPath") ? await Utility.getPythonPath(this._document) : Constants.python;
             const placeholders: Array<{ regex: RegExp, replaceValue: string }> = [
+                // A placeholder that has to be replaced by the directory of the workspace with quotes
+                { regex: /\$workspaceRootWithQuotes/g, replaceValue: this.quoteFileName(this.getWorkspaceRoot(codeFileDir)) },
                 // A placeholder that has to be replaced by the path of the folder opened in VS Code
                 // If no folder is opened, replace with the directory of the code file
                 { regex: /\$workspaceRoot/g, replaceValue: this.getWorkspaceRoot(codeFileDir) },
@@ -371,6 +399,8 @@ export class CodeManager implements vscode.Disposable {
                 { regex: /\$fileName/g, replaceValue: this.getCodeBaseFile() },
                 // A placeholder that has to be replaced by the drive letter of the code file (Windows only)
                 { regex: /\$driveLetter/g, replaceValue: this.getDriveLetter() },
+                // A placeholder that has to be replaced by the package name for java files
+                { regex: /\$javaPackageName/g, replaceValue: this.getJavaFilePackageName() },
                 // A placeholder that has to be replaced by the directory of the code file without a trailing slash
                 { regex: /\$dirWithoutTrailingSlash/g, replaceValue: this.quoteFileName(this.getCodeFileDirWithoutTrailingSlash()) },
                 // A placeholder that has to be replaced by the directory of the code file


### PR DESCRIPTION
This pull request fixes Issue #169 

1. added additional parameter javaPackageName which gets the package
   name from java file
2. added parameter workspaceRootWithQuotes. This is needed to in windows
   to CD to the directory and set classpath

Now, we can run a java file with or without package name using below
sample command

"java": "cd $workspaceRootWithQuotes && javac $fullFileName && java -cp $workspaceRootWithQuotes $javaPackageName$fileNameWithoutExt"