### PR TITLE
Fix for #858

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 npm-debug.log
 out
 node_modules
+yarn.lock

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -402,16 +402,17 @@ export class CodeManager implements vscode.Disposable {
 
     private isPowershellOnWindows(): boolean {
         if (os.platform() === "win32") {
+            const windowsShell = vscode.env.shell;
             const defaultProfile = vscode.workspace.getConfiguration("terminal").get<string>("integrated.defaultProfile.windows");
-			const windowsShell = vscode.env.shell;
-            if (defaultProfile) {
-                if (defaultProfile.toLowerCase().includes("powershell") || windowsShell.toLowerCase().includes("powershell")) {
-                    return true;
-                } else if (defaultProfile === "Command Prompt") {
-                    return false;
-                }
+            if (windowsShell && windowsShell.toLocaleLowerCase().includes("powershell")) {
+                return true;
             }
-            return (windowsShell && windowsShell.toLowerCase().includes("powershell"));
+
+            if (defaultProfile && defaultProfile.toLocaleLowerCase().includes("powershell")) {
+                return true;
+            }
+
+            return false;
         }
         return false;
     }

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -403,14 +403,14 @@ export class CodeManager implements vscode.Disposable {
     private isPowershellOnWindows(): boolean {
         if (os.platform() === "win32") {
             const defaultProfile = vscode.workspace.getConfiguration("terminal").get<string>("integrated.defaultProfile.windows");
+			const windowsShell = vscode.env.shell;
             if (defaultProfile) {
-                if (defaultProfile.toLowerCase().includes("powershell")) {
+                if (defaultProfile.toLowerCase().includes("powershell") || windowsShell.toLowerCase().includes("powershell")) {
                     return true;
                 } else if (defaultProfile === "Command Prompt") {
                     return false;
                 }
             }
-            const windowsShell = vscode.env.shell;
             return (windowsShell && windowsShell.toLowerCase().includes("powershell"));
         }
         return false;

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -411,8 +411,6 @@ export class CodeManager implements vscode.Disposable {
             if (defaultProfile && defaultProfile.toLocaleLowerCase().includes("powershell")) {
                 return true;
             }
-
-            return false;
         }
         return false;
     }


### PR DESCRIPTION
Improved the `isPowershellOnWindows` to detect if the current shell is PowerShell or not. This will fix the build failures in VSCode 1.60.
@formulahendry  review this, please.