### PR TITLE
fix compatibility with ms-python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 npm-debug.log
 out
 node_modules
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -295,6 +295,12 @@
           "description": "Whether to run code in Integrated Terminal.",
           "scope": "resource"
         },
+        "code-runner.runWithPythonExtension": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to run Python code with ms-python extension",
+          "scope": "resource"
+        },
         "code-runner.terminalRoot": {
           "type": "string",
           "default": "",

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -436,6 +436,16 @@ export class CodeManager implements vscode.Disposable {
     }
 
     private async executeCommandInTerminal(executor: string, appendFile: boolean = true) {
+        if (this._config.get<boolean>("runWithPythonExtension") && executor.startsWith('python')) {
+            const python_ext = vscode.extensions.getExtension('ms-python.python');
+            if (python_ext?.isActive) {
+                await vscode.commands.executeCommand('python.execInTerminal');
+                return;
+            } else {
+                vscode.window.showErrorMessage('ms-python did not activated');
+                return;
+            }
+        }
         let isNewTerminal = false;
         if (this._terminal === null) {
             this._terminal = vscode.window.createTerminal("Code");


### PR DESCRIPTION
Fixes #878 #855 #576 #434 
Many python users like to use conda or something else to control the virtual environment. But code runner does not supprot it. When ms-python extension has been installed, it will firstly execute the command and then activate the virtual environment, so it won't work well with python at the first execution.
I just add an option to make users to choose whether to execute the command with official python extension.