### PR TITLE
Add input support when running in OutputChannel

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,10 @@
         "key": "ctrl+alt+j"
       },
       {
+        "command": "code-runner.inputProcess",
+        "key": "ctrl+alt+i"
+      },
+      {
         "command": "code-runner.stop",
         "key": "ctrl+alt+m"
       }

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -108,7 +108,7 @@ export class CodeManager implements vscode.Disposable {
             vscode.window.showInputBox().then((msg) => {
                 if (msg !== undefined) {
                     this._process.stdin.write(msg);
-                    this._process.stdin.write('\r\n');
+                    this._process.stdin.write("\r\n");
                 }
             });
         } else {

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -103,6 +103,19 @@ export class CodeManager implements vscode.Disposable {
         });
     }
 
+    public inputProcess(): void {
+        if (this._isRunning) {
+            vscode.window.showInputBox().then((msg) => {
+                if (msg !== undefined) {
+                    this._process.stdin.write(msg);
+                    this._process.stdin.write('\r\n');
+                }
+            });
+        } else {
+            vscode.window.showInformationMessage("Code is not running!");
+        }
+    }
+
     public stop(): void {
         this._appInsightsClient.sendEvent("stop");
         this.stopRunning();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,10 @@ export function activate(context: vscode.ExtensionContext) {
         codeManager.runByLanguage();
     });
 
+    const inputProcess = vscode.commands.registerCommand("code-runner.inputProcess", () => {
+        codeManager.inputProcess();
+    });
+
     const stop = vscode.commands.registerCommand("code-runner.stop", () => {
         codeManager.stop();
     });
@@ -29,6 +33,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(run);
     context.subscriptions.push(runCustomCommand);
     context.subscriptions.push(runByLanguage);
+    context.subscriptions.push(inputProcess);
     context.subscriptions.push(stop);
     context.subscriptions.push(codeManager);
 }


### PR DESCRIPTION
Use keybindings (default: `ctrl+alt+i`) to write to the input stream of the running process when `executeCommandInOutputChannel`.