### PR TITLE
Add Virtual Workspaces Support feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -379,5 +379,10 @@
     "mocha": "^6.1.4",
     "tslint": "^5.5.0",
     "typescript": "^3.8.3"
+  },
+    "capabilities": {
+    "virtualWorkspaces": {
+      "supported": true
+    }
   }
 }


### PR DESCRIPTION
I noticed that in the case of loading remote workspace file the extension is disabled by default and VS reports that it does not support virtual workspace which is not true because logging directly through the terminal I could run code over ssh session which is the case not dealing with workspace files.