### PR TITLE
Fix Executor map for Python

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
             "cpp": "cd $dir && g++ $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
             "objective-c": "cd $dir && gcc -framework Cocoa $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
             "php": "php",
-            "python": "python -u",
+            "python": "python3 -u",
             "perl": "perl",
             "perl6": "perl6",
             "ruby": "ruby",


### PR DESCRIPTION
Found it to not be compatible with new Python3