### PR TITLE
change command for Rust to `cargo run`

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
             "applescript": "osascript",
             "clojure": "lein exec",
             "haxe": "haxe --cwd $dirWithoutTrailingSlash --run $fileNameWithoutExt",
-            "rust": "cd $dir && rustc $fileName && $dir$fileNameWithoutExt",
+            "rust": "cargo run",
             "racket": "racket",
             "scheme": "csi -script",
             "ahk": "autohotkey",


### PR DESCRIPTION
Cargo is part of the default toolchain.
Using rustc directly will fail if there's any external packages used. Files other than main in a Rust project are usually not meant to be executed directly. Because of all of the above, running `cargo run` has a much higher chance to produce the desired result.