### PR TITLE
Change the path in the command

### DIFF
--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -426,6 +426,10 @@ export class CodeManager implements vscode.Disposable {
                     .replace(/\\/g, "/");
             } else if (windowsShell && windowsShell.toLowerCase().indexOf("bash") > -1 && windowsShell.toLowerCase().indexOf("windows") > -1) {
                 command = command.replace(/([A-Za-z]):\\/g, this.replacer).replace(/\\/g, "/");
+            } else if (windowsShell && windowsShell.toLowerCase().indexOf("wsl") > -1) {
+                command = command.replace(/([A-Za-z]):\\/g, this.replacer).replace(/\\/g, "/");
+            } else if (windowsShell && windowsShell.toLowerCase().indexOf("bash") > -1  && command.includes("&&")) {
+                command = command.replace(/\\/g, "/");
             }
         }
         return command;


### PR DESCRIPTION
When executing code runner in git bash, the path will be "\" not supported by the terminal instead of "/", as shown below
![image](https://user-images.githubusercontent.com/95022717/201667080-cdfbcf48-b9fb-42ca-a087-d8deaa27af2a.png)
And when unbuntu (wsl) is executed, the path does not start with "/mnt/", as shown below
![image](https://user-images.githubusercontent.com/95022717/201668624-0bb7c865-38bb-4f29-a102-6b526f8a4e1b.png)

