### PR TITLE
Add Kotlin JAR cleanup step in Code Runner Extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
             ".scm": "csi -script",
             ".ahk": "autohotkey",
             ".au3": "autoit3",
-            ".kt": "cd $dir && kotlinc $fileName -include-runtime -d $fileNameWithoutExt.jar && java -jar $fileNameWithoutExt.jar",
+            ".kt": "cd $dir && kotlinc $fileName -include-runtime -d $fileNameWithoutExt.jar && java -jar $fileNameWithoutExt.jar && rm $fileNameWithoutExt.jar",
             ".kts": "kotlinc -script",
             ".dart": "dart",
             ".pas": "cd $dir && fpc $fileName && $dir$fileNameWithoutExt",


### PR DESCRIPTION
This PR introduces a new step to the Kotlin code execution process in the Code Runner extension. Specifically, it adds a command to delete the generated JAR file (`rm $fileNameWithoutExt.jar`) after the Kotlin code has been executed.

The purpose of this change is to reduce clutter by removing the generated JAR file post-execution, thereby improving the user experience. 

Please review this change and let me know if any adjustments are needed.