### PR TITLE
added python utf-8 encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
             "cpp": "cd $dir && g++ $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
             "objective-c": "cd $dir && gcc -framework Cocoa $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
             "php": "php",
-            "python": "python -u",
+            "python": "set PYTHONIOENCODING=utf8 && py -u",
             "perl": "perl",
             "perl6": "perl6",
             "ruby": "ruby",


### PR DESCRIPTION
Russian and other languages fail because of the executorMap being undefined when using code runners terminal instead of the built-in vscode terminal.