### PR TITLE
Fix vs code global output coloring+links detection conflicts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,10 @@
         "@types/micromatch": "^3.1.0",
         "@types/mocha": "^2.2.32",
         "@types/node": "^6.0.40",
-        "@types/vscode": "^1.56.0",
+        "@types/vscode": "^1.66.0",
         "mocha": "^6.1.4",
         "tslint": "^5.5.0",
-        "typescript": "^3.8.3"
+        "typescript": "^4.0.0"
       },
       "engines": {
         "vscode": "^1.56.0"
@@ -53,9 +53,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.56.0.tgz",
-      "integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==",
+      "version": "1.85.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.85.0.tgz",
+      "integrity": "sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==",
       "dev": true
     },
     "node_modules/ansi-colors": {
@@ -1372,9 +1372,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -1617,9 +1617,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.56.0.tgz",
-      "integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==",
+      "version": "1.85.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.85.0.tgz",
+      "integrity": "sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==",
       "dev": true
     },
     "ansi-colors": {
@@ -2654,9 +2654,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "publisher": "formulahendry",
   "icon": "images/logo.png",
   "engines": {
-    "vscode": "^1.56.0"
+    "vscode": "^1.66.0"
   },
   "categories": [
     "Programming Languages",
@@ -358,7 +358,7 @@
       {
         "id": "code-runner-output",
         "mimetypes": [
-          "text/x-code-output"
+          "text/x-code-output-log"
         ]
       }
     ],
@@ -384,9 +384,9 @@
     "@types/micromatch": "^3.1.0",
     "@types/mocha": "^2.2.32",
     "@types/node": "^6.0.40",
-    "@types/vscode": "^1.56.0",
+    "@types/vscode": "^1.66.0",
     "mocha": "^6.1.4",
     "tslint": "^5.5.0",
-    "typescript": "^3.8.3"
+    "typescript": "^4.0.0"
   }
 }

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -27,7 +27,7 @@ export class CodeManager implements vscode.Disposable {
     private _TERMINAL_DEFAULT_SHELL_WINDOWS: string | null = null;
 
     constructor() {
-        this._outputChannel = vscode.window.createOutputChannel("Code");
+        this._outputChannel = vscode.window.createOutputChannel("Code", "code-runner-output");
         this._terminal = null;
         this._appInsightsClient = new AppInsightsClient();
     }


### PR DESCRIPTION
It fixes the conflicts generated by the extension in the output window (broken coloring and clickable link detection), also it allows to use output coloring extensions such as https://marketplace.visualstudio.com/items?itemName=IBM.output-colorizer and https://marketplace.visualstudio.com/items?itemName=SteveBushResearch.BuildOutputColorizer.

I updated the minimum vs code version to v1.66 and typescript to v4 to fix compiling errors due to the new vsc API used.