### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
             ".vsh": "v run",
             ".sass": "sass --style expanded",
             ".cu": "cd $dir && nvcc $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
-            ".ring": "ring",
+            ".ring": "cd $dir && ring $fileName",
             ".sml": "cd $dir && sml $fileName",
             ".mojo": "mojo run",
             ".erl": "escript"


### PR DESCRIPTION
Ring language support - Move to the application folder before execution because most of Ring applications/samples that comes with Ring uses relative path and expect that the current folder is the application folder.