### PR TITLE
Update C# script runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ To set whether to preserve focus on code editor after code run is triggered (def
 
 ## Note
 * For Objective-C, it is only supported on macOS
-* To run C# script, you need to install [scriptcs](http://scriptcs.net/)
+* To run C# scripts, you need to install [dotnet-script](https://github.com/dotnet-script/dotnet-script)
 * To run TypeScript, you need to install [ts-node](https://github.com/TypeStrong/ts-node)
 * To run Clojure, you need to install [Leiningen](https://leiningen.org/) and [lein-exec](https://github.com/kumarshantanu/lein-exec)
 

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
             "bat": "cmd /c",
             "shellscript": "bash",
             "fsharp": "fsi",
-            "csharp": "scriptcs",
+            "csharp": "dotnet script",
             "vbscript": "cscript //Nologo",
             "typescript": "ts-node",
             "coffeescript": "coffee",


### PR DESCRIPTION
Closes #1150 

There are a couple of C# script runner options but `dotnet-script` seemed well supported and worked with my testing.