### PR TITLE
Added code-runner.stopWait command

### DIFF
--- a/!Build.ps1
+++ b/!Build.ps1
@@ -1,0 +1,18 @@
+﻿tsc --build --verbose
+
+vsce package --allow-missing-repository --allow-star-activation
+Write-Host
+
+$name = Get-ChildItem -Name -File -Filter *.vsix | Select-Object -First 1
+Invoke-Expression "code --force --install-extension $name"
+Write-Host
+
+Write-Host "AHK"
+RunAhk.ps1 @'
+WinActivate "ahk_exe Code.exe"
+WinWaitActive "ahk_exe Code.exe"
+Send "^!+r"
+'@
+Write-Host
+
+PressEnterToContinue.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 out
 node_modules
 *.vsix
+!Build.ps1

--- a/package.json
+++ b/package.json
@@ -62,6 +62,11 @@
         "command": "code-runner.stop",
         "title": "Stop Code Run",
         "icon": "$(debug-stop)"
+      },
+      {
+        "command": "code-runner.stopWait",
+        "title": "Stop Code Run and wait for it to exit",
+        "icon": "$(debug-stop)"
       }
     ],
     "keybindings": [

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -475,7 +475,8 @@ export class CodeManager implements vscode.Disposable {
         this.sendRunEvent(executor, false);
         let resolveClosePromise;
         this._closePromise = new Promise<void>(resolve => (resolveClosePromise = resolve));
-        const startTime = new Date();
+        const { performance } = require('node:perf_hooks');
+        const startTime = performance.now();
         this._process = spawn(command, [], { cwd: this._cwd, shell: true });
 
         this._process.stdout.on("data", (data) => {
@@ -489,11 +490,11 @@ export class CodeManager implements vscode.Disposable {
         this._process.on("close", (code) => {
             this._isRunning = false;
             vscode.commands.executeCommand("setContext", "code-runner.codeRunning", false);
-            const endTime = new Date();
-            const elapsedTime = (endTime.getTime() - startTime.getTime()) / 1000;
+            const endTime = performance.now();
+            const elapsedTime = (endTime - startTime) / 1000;
             this._outputChannel.appendLine("");
             if (showExecutionMessage) {
-                this._outputChannel.appendLine("[Done] exited with code=" + code + " in " + elapsedTime + " seconds");
+                this._outputChannel.appendLine("[Done] exited with code=" + code + " in " + elapsedTime.toFixed(3) + " seconds");
                 this._outputChannel.appendLine("");
             }
             if (this._isTmpFile) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,10 +26,15 @@ export function activate(context: vscode.ExtensionContext) {
         codeManager.stop();
     });
 
+    const stopWait = vscode.commands.registerCommand("code-runner.stopWait", () => {
+        return codeManager.stop();
+    });
+
     context.subscriptions.push(run);
     context.subscriptions.push(runCustomCommand);
     context.subscriptions.push(runByLanguage);
     context.subscriptions.push(stop);
+    context.subscriptions.push(stopWait);
     context.subscriptions.push(codeManager);
 }
 


### PR DESCRIPTION
I find it annoying having to close windows produced by Python's `matplotlib.pyplot` before running the code again.

So I created this keyboard shortcut:
```json
    {
        "key": "f5",
        "command": "runCommands",
        "args": {
            "commands": [
                "code-runner.stop",
                "code-runner.run",
            ]
        },
    },
```
But the `run` commands was being executed too soon - before previous process fully closed - so the new process could not be registered correctly. The result was that new processes (`matplotlib` windows) would spawn every time I pressed `F5`.

So I created `stopWait` command that waits for the process to emit `"close"` event after it receives the kill signal.

It is a drop-in replacement for the `stop` command in the shortcut:
```json
    {
        "key": "f5",
        "command": "runCommands",
        "args": {
            "commands": [
                "code-runner.stopWait",
                "code-runner.run",
            ]
        },
    },
```
I'm using Python as an example here but this should work for any programming language that waits for anything when run (i.e. user input, network request).