### PR TITLE
[Feature] Add setting to only show run button on files with executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,9 @@ To set whether to preserve focus on code editor after code run is triggered (def
 
 `code-runner.ignoreSelection`: Whether to ignore selection to always run entire file. (Default is **false**)
 
-`code-runner.showRunIconInEditorTitleMenu`: Whether to show 'Run Code' icon in editor title menu. (Default is **true**)
+`code-runner.onlyShowRunIconIfExecutorExists`: Whether to only show 'Run Code' icon in editor title menu if the current file can be ran. If false, the icon will show for every file. (Default is **true**)
+
+`code-runner.showRunIconInEditorTitleMenu`: Whether to show 'Run Code' icon in editor title menu. If false, overrides `code-runner.onlyShowRunIconIfExecutorExists` setting. (Default is **true**)
 
 `code-runner.showRunCommandInEditorContextMenu`: Whether to show 'Run Code' command in editor context menu. (Default is **true**)
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
       ],
       "editor/title/run": [
         {
-          "when": "config.code-runner.showRunIconInEditorTitleMenu",
+          "when": "code-runner.showRunButton",
           "command": "code-runner.run",
           "group": "navigation"
         }
@@ -324,10 +324,16 @@
           "description": "Whether to ignore selection to always run entire file.",
           "scope": "resource"
         },
+        "code-runner.onlyShowRunIconIfExecutorExists": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to only show 'Run Code' icon in editor title menu if the current file can be ran. If false, the icon will show for every file.",
+          "scope": "resource"
+        },
         "code-runner.showRunIconInEditorTitleMenu": {
           "type": "boolean",
           "default": true,
-          "description": "Whether to show 'Run Code' icon in editor title menu.",
+          "description": "Whether to show 'Run Code' icon in editor title menu. If false, overrides `code-runner.onlyShowRunIconIfExecutorExists` setting.",
           "scope": "resource"
         },
         "code-runner.showStopIconInEditorTitleMenu": {

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -112,6 +112,22 @@ export class CodeManager implements vscode.Disposable {
         this.stopRunning();
     }
 
+    public fileHasExecutor(): boolean {
+        const editor = vscode.window.activeTextEditor;
+        if (editor) {
+            this._document = editor.document;
+        }
+
+        if (!this._document) {
+            return false;
+        }
+
+        this.initialize();
+        const fileExtension = extname(this._document.fileName);
+        const executor = this.getExecutor(this._document.languageId, fileExtension);
+        return executor != null;
+    }
+
     private checkIsRunFromExplorer(fileUri: vscode.Uri): boolean {
         const editor = vscode.window.activeTextEditor;
         if (!fileUri || !fileUri.fsPath) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,25 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(runByLanguage);
     context.subscriptions.push(stop);
     context.subscriptions.push(codeManager);
+
+    const updateContext = () => {
+        const config = vscode.workspace.getConfiguration("code-runner");
+        if (!config.get<boolean>("showRunIconInEditorTitleMenu", true)) {
+            vscode.commands.executeCommand("setContext", "code-runner.showRunButton", false);
+            return;
+        }
+
+        if (!config.get<boolean>("onlyShowRunIconIfExecutorExists", true)) {
+            vscode.commands.executeCommand("setContext", "code-runner.showRunButton", true);
+            return;
+        }
+
+        vscode.commands.executeCommand("setContext", "code-runner.showRunButton", codeManager.fileHasExecutor());
+    };
+    vscode.workspace.onDidChangeConfiguration(updateContext);
+    vscode.window.onDidChangeActiveTextEditor(updateContext);
+
+    updateContext();
 }
 
 export function deactivate() {


### PR DESCRIPTION
By default, the run button will not show for files that have no executor (i.e, files that say `Code language not supported or defined`).

# Changes to settings
- ## (NEW) `code-runner.onlyShowRunIconIfExecutorExists`
  - Default: true 
  - The arrow in the title bar will only be shown if the file can be executed.
- ## `code-runner.showRunIconInEditorTitleMenu`
  - If set to false, it will override `code-runner.onlyShowRunIconIfExecutorExists`.

# Changes to code
- ## (NEW) `fileHasExecutor()`
  - Public method
  - Returns a boolean saying if the current file has an executor.
- ## (NEW) `updateContext`
  - Handles all the logic.