### PR TITLE
[Feature/Fix] Add settings to override objects that would merge with default

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ Also, you could set the executor per file extension:
 }
 ```
 
+**Note:** All of `code-runner.executorMapByFileExtension`, `code-runner.executorMapByGlob`, and `code-runner.executorMap` merge the default setting with what you set. If you want to remove one of the defaults, you can switch your setting to use `code-runner.executorMapByFileExtensionOverride`, `code-runner.executorMapByGlobOverride`, and `code-runner.executorMapOverride` respectively.
+Also, setting an override to only `{ "": "" }` may not work as expected. Make sure the key is not blank.
+
 To set the custom command to run:
 ```json
 {
@@ -127,7 +130,7 @@ To set the custom command to run:
 }
 ```
 
-To set the the working directory:
+To set the working directory:
 ```json
 {
     "code-runner.cwd": "path/to/working/directory"

--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ Also, you could set the executor per file extension:
 ```
 
 **Note:** All of `code-runner.executorMapByFileExtension`, `code-runner.executorMapByGlob`, and `code-runner.executorMap` merge the default setting with what you set. If you want to remove one of the defaults, you can switch your setting to use `code-runner.executorMapByFileExtensionOverride`, `code-runner.executorMapByGlobOverride`, and `code-runner.executorMapOverride` respectively.
-Also, setting an override to only `{ "": "" }` may not work as expected. Make sure the key is not blank.
 
 To set the custom command to run:
 ```json

--- a/package.json
+++ b/package.json
@@ -129,6 +129,12 @@
           "description": "Set the executor by glob.",
           "scope": "resource"
         },
+        "code-runner.executorMapByGlobOverride": {
+          "type": "object",
+          "default": {},
+          "description": "If set, overrides `code-runner.executorMapByGlob` without merging the default settings.",
+          "scope": "resource"
+        },
         "code-runner.executorMap": {
           "type": "object",
           "default": {
@@ -193,6 +199,12 @@
           "description": "Set the executor of each language.",
           "scope": "resource"
         },
+        "code-runner.executorMapOverride": {
+          "type": "object",
+          "default": {},
+          "description": "If set, overrides `code-runner.executorMap` without merging the default settings.",
+          "scope": "resource"
+        },
         "code-runner.executorMapByFileExtension": {
           "type": "object",
           "default": {
@@ -236,6 +248,12 @@
           "description": "Set the executor of each file extension.",
           "scope": "resource"
         },
+        "code-runner.executorMapByFileExtensionOverride": {
+          "type": "object",
+          "default": {},
+          "description": "If set, overrides `code-runner.executorMapByFileExtension` without merging the default settings.",
+          "scope": "resource"
+        },
         "code-runner.customCommand": {
           "type": "string",
           "default": "echo Hello",
@@ -250,6 +268,12 @@
             "typescript": ".ts"
           },
           "description": "Set the mapping of languageId to file extension.",
+          "scope": "resource"
+        },
+        "code-runner.languageIdToFileExtensionMapOverride": {
+          "type": "object",
+          "default": {},
+          "description": "If set, overrides `code-runner.languageIdToFileExtensionMap` without merging the default settings.",
           "scope": "resource"
         },
         "code-runner.defaultLanguage": {

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -220,18 +220,15 @@ export class CodeManager implements vscode.Disposable {
 
     private createRandomFile(content: string, folder: string, fileExtension: string) {
         let fileType = "";
-        let languageIdToFileExtensionMap = this._config.get<any>("languageIdToFileExtensionMapOverride");
-        if (!languageIdToFileExtensionMap || Object.keys(languageIdToFileExtensionMap).length === 0) {
-            languageIdToFileExtensionMap = this._config.get<any>("languageIdToFileExtensionMap");
-        }
-        if (this._languageId && languageIdToFileExtensionMap[this._languageId]) {
-            fileType = languageIdToFileExtensionMap[this._languageId];
-        } else {
-            if (fileExtension) {
-                fileType = fileExtension;
-            } else {
-                fileType = "." + this._languageId;
+        if (this._languageId && this._languageId !== "") {
+            let languageIdToFileExtensionMap = this._config.get<any>("languageIdToFileExtensionMapOverride", {});
+            if (Object.keys(languageIdToFileExtensionMap).length === 0) {
+                languageIdToFileExtensionMap = this._config.get<any>("languageIdToFileExtensionMap", {});
             }
+
+            fileType = languageIdToFileExtensionMap[this._languageId] ?? fileExtension ?? ("." + this._languageId);
+        } else {
+            fileType = fileExtension ?? ("." + (this._languageId || ""));
         }
         const temporaryFileName = this._config.get<string>("temporaryFileName");
         const tmpFileNameWithoutExt = temporaryFileName ? temporaryFileName : "temp" + this.rndName();
@@ -255,17 +252,16 @@ export class CodeManager implements vscode.Disposable {
 
         if (executor == null) {
             let executorMapByGlob = this._config.get<any>("executorMapByGlobOverride", {});
-            if (!executorMapByGlob || Object.keys(executorMapByGlob).length === 0) {
-                executorMapByGlob = this._config.get<any>("executorMapByGlob");
+            if (Object.keys(executorMapByGlob).length === 0) {
+                executorMapByGlob = this._config.get<any>("executorMapByGlob", {});
             }
 
-            if (executorMapByGlob) {
-                const fileBasename = basename(this._document.fileName);
-                for (const glob of Object.keys(executorMapByGlob)) {
-                    if (micromatch.isMatch(fileBasename, glob)) {
-                        executor = executorMapByGlob[glob];
-                        break;
-                    }
+            executorMapByGlob = Object.fromEntries(Object.entries(executorMapByGlob).filter(([key]) => key !== ""))
+            const fileBasename = basename(this._document.fileName);
+            for (const glob of Object.keys(executorMapByGlob)) {
+                if (micromatch.isMatch(fileBasename, glob)) {
+                    executor = executorMapByGlob[glob];
+                    break;
                 }
             }
         }
@@ -277,10 +273,10 @@ export class CodeManager implements vscode.Disposable {
         }
 
         // executor is undefined or null
-        if (executor == null && fileExtension) {
+        if (executor == null && fileExtension && fileExtension !== "") {
             let executorMapByFileExtension = this._config.get<any>("executorMapByFileExtensionOverride", {});
-            if (!executorMapByFileExtension || Object.keys(executorMapByFileExtension).length === 0) {
-                executorMapByFileExtension = this._config.get<any>("executorMapByFileExtension");
+            if (Object.keys(executorMapByFileExtension).length === 0) {
+                executorMapByFileExtension = this._config.get<any>("executorMapByFileExtension", {});
             }
             executor = executorMapByFileExtension[fileExtension];
             if (executor != null) {
@@ -296,11 +292,11 @@ export class CodeManager implements vscode.Disposable {
     }
 
     private getExecutorMap(config: vscode.WorkspaceConfiguration): any {
-        const executorMapOverride = config.get<any>("executorMapOverride", {});
-        if (!executorMapOverride || Object.keys(executorMapOverride).length === 0) {
-            return config.get<any>("executorMap");
+        let executorMap = config.get<any>("executorMapOverride", {});
+        if (Object.keys(executorMap).length === 0) {
+            executorMap = config.get<any>("executorMap", {});
         }
-        return executorMapOverride;
+        return Object.fromEntries(Object.entries(executorMap).filter(([key]) => key !== ""));
     }
 
     private executeCommand(executor: string, appendFile: boolean = true) {

--- a/src/codeManager.ts
+++ b/src/codeManager.ts
@@ -95,7 +95,7 @@ export class CodeManager implements vscode.Disposable {
     public runByLanguage(): void {
         this._appInsightsClient.sendEvent("runByLanguage");
         const config = this.getConfiguration("code-runner");
-        const executorMap = config.get<any>("executorMap");
+        const executorMap = this.getExecutorMap(config);
         vscode.window.showQuickPick(Object.keys(executorMap), { placeHolder: "Type or select language to run" }).then((languageId) => {
             if (languageId !== undefined) {
                 this.run(languageId);
@@ -220,7 +220,10 @@ export class CodeManager implements vscode.Disposable {
 
     private createRandomFile(content: string, folder: string, fileExtension: string) {
         let fileType = "";
-        const languageIdToFileExtensionMap = this._config.get<any>("languageIdToFileExtensionMap");
+        let languageIdToFileExtensionMap = this._config.get<any>("languageIdToFileExtensionMapOverride");
+        if (!languageIdToFileExtensionMap || Object.keys(languageIdToFileExtensionMap).length === 0) {
+            languageIdToFileExtensionMap = this._config.get<any>("languageIdToFileExtensionMap");
+        }
         if (this._languageId && languageIdToFileExtensionMap[this._languageId]) {
             fileType = languageIdToFileExtensionMap[this._languageId];
         } else {
@@ -251,7 +254,11 @@ export class CodeManager implements vscode.Disposable {
         }
 
         if (executor == null) {
-            const executorMapByGlob = this._config.get<any>("executorMapByGlob");
+            let executorMapByGlob = this._config.get<any>("executorMapByGlobOverride", {});
+            if (!executorMapByGlob || Object.keys(executorMapByGlob).length === 0) {
+                executorMapByGlob = this._config.get<any>("executorMapByGlob");
+            }
+
             if (executorMapByGlob) {
                 const fileBasename = basename(this._document.fileName);
                 for (const glob of Object.keys(executorMapByGlob)) {
@@ -263,7 +270,7 @@ export class CodeManager implements vscode.Disposable {
             }
         }
 
-        const executorMap = this._config.get<any>("executorMap");
+        const executorMap = this.getExecutorMap(this._config);
 
         if (executor == null) {
             executor = executorMap[this._languageId];
@@ -271,7 +278,10 @@ export class CodeManager implements vscode.Disposable {
 
         // executor is undefined or null
         if (executor == null && fileExtension) {
-            const executorMapByFileExtension = this._config.get<any>("executorMapByFileExtension");
+            let executorMapByFileExtension = this._config.get<any>("executorMapByFileExtensionOverride", {});
+            if (!executorMapByFileExtension || Object.keys(executorMapByFileExtension).length === 0) {
+                executorMapByFileExtension = this._config.get<any>("executorMapByFileExtension");
+            }
             executor = executorMapByFileExtension[fileExtension];
             if (executor != null) {
                 this._languageId = fileExtension;
@@ -283,6 +293,14 @@ export class CodeManager implements vscode.Disposable {
         }
 
         return executor;
+    }
+
+    private getExecutorMap(config: vscode.WorkspaceConfiguration): any {
+        const executorMapOverride = config.get<any>("executorMapOverride", {});
+        if (!executorMapOverride || Object.keys(executorMapOverride).length === 0) {
+            return config.get<any>("executorMap");
+        }
+        return executorMapOverride;
     }
 
     private executeCommand(executor: string, appendFile: boolean = true) {


### PR DESCRIPTION
When you changed an object in your settings.json, it would merge the defaults of the setting when `config.get()` was run. This adds new settings for each object that, when set, the base setting (along with its defaults) will be ignored.

`code-runner.executorMapByFileExtensionOverride`
`code-runner.executorMapByGlobOverride`
`code-runner.executorMapOverride`
`code-runner.languageIdToFileExtensionMapOverride`